### PR TITLE
Remove /#/ in favor of "prettier" URLs "/" via the HTML5 History API …

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,6 +6,8 @@
 // use this if you want to recursively match all subfolders:
 // 'test/spec/**/*.js'
 
+var modRewrite = require('connect-modrewrite');
+
 module.exports = function (grunt) {
 
   // Load grunt tasks automatically
@@ -82,6 +84,7 @@ module.exports = function (grunt) {
           open: true,
           middleware: function (connect) {
             return [
+              modRewrite(['^[^\\.]*$ /index.html [L]']),
               connect.static('.tmp'),
               connect().use('/bower_components', connect.static('./bower_components')),
               connect().use('/app/styles', connect.static('./app/styles')),

--- a/app/index.html
+++ b/app/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Your STL Courts</title>
+    <base href="/">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
@@ -61,7 +62,7 @@
     <script src="bower_components/ui-leaflet/dist/ui-leaflet.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
-    
+
 
     <!-- build:js({.tmp,app}) scripts/scripts.js -->
     <script src="vendor/jcs-auto-validate.min.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -3,7 +3,8 @@
 angular.module('yourStlCourts', ['ngResource', 'ngSanitize', 'ngTouch', 'envConfig', 'ui.router', 'esri.map', 'toaster',
   'ui.bootstrap', 'ui.select', 'jcs-autoValidate','ui-leaflet']);
 
-angular.module('yourStlCourts').config(function($stateProvider, $urlRouterProvider, ENV, $httpProvider, uiSelectConfig) {
+angular.module('yourStlCourts').config(function($stateProvider, $urlRouterProvider, $locationProvider, ENV, $httpProvider, uiSelectConfig) {
+  $locationProvider.html5Mode(true);
   $urlRouterProvider.otherwise('/');
 
   $stateProvider

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -56,5 +56,16 @@ http {
         location /api {
             proxy_pass http://API;
         }
+
+        location / {
+              # Make sure to pass any headers through the proxy here and not inside the if statements !
+              proxy_set_header Host $host;
+              proxy_set_header Accept-Encoding "";
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+
+              try_files $uri /index.html;
+          }
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.0",
   "private": true,
   "devDependencies": {
+    "connect-modrewrite": "^0.9.0",
     "grunt": "^0.4.5",
     "grunt-angular-templates": "^0.5.7",
     "grunt-autoprefixer": "^3.0.4",
@@ -29,7 +30,7 @@
     "grunt-wiredep": "^2.0.0",
     "jit-grunt": "^0.9.1",
     "jshint-stylish": "^1.0.0",
-    "karma":"^1.1.2",
+    "karma": "^1.1.2",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "*",
     "karma-phantomjs-launcher": "*",


### PR DESCRIPTION
…which is supported in every browser we care about. Also enables the legitimate use of anchor ("#") tags on court info page.